### PR TITLE
Implement screenshot grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,7 @@
 
   </head>
   <body>
-    <h1>💖 Hello World!</h1>
-    <p>Welcome to your Electron application.</p>
+    <div id="grid"></div>
     <script type="module" src="/src/renderer.ts"></script>
   </body>
 </html>

--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,28 @@
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica,
     Arial, sans-serif;
-  margin: auto;
-  max-width: 38rem;
-  padding: 2rem;
+  margin: 0;
+  padding: 1rem;
+}
+
+#grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 8px;
+}
+
+.grid-item {
+  width: 100%;
+  padding-top: 100%;
+  position: relative;
+  overflow: hidden;
+}
+
+.grid-item img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,2 +1,9 @@
-// See the Electron documentation for details on how to use preload scripts:
-// https://www.electronjs.org/docs/latest/tutorial/process-model#preload-scripts
+import { contextBridge, ipcRenderer } from "electron";
+
+contextBridge.exposeInMainWorld("electronAPI", {
+  getScreenshots: () => ipcRenderer.invoke("get-screenshots"),
+  onScreenshotsUpdated: (cb: (paths: string[]) => void) =>
+    ipcRenderer.on("screenshots-updated", (_e, paths) => cb(paths)),
+  openFile: (p: string) => ipcRenderer.invoke("open-file", p),
+});
+

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -26,6 +26,33 @@
  * ```
  */
 
-import './index.css';
+import "./index.css";
 
-console.log('👋 This message is being logged by "renderer.ts", included via Vite');
+declare global {
+  interface Window {
+    electronAPI: {
+      getScreenshots: () => Promise<string[]>;
+      onScreenshotsUpdated: (cb: (paths: string[]) => void) => void;
+      openFile: (p: string) => Promise<void>;
+    };
+  }
+}
+
+const grid = document.getElementById("grid") as HTMLElement;
+
+function renderGrid(paths: string[]) {
+  grid.innerHTML = "";
+  paths.forEach((p) => {
+    const item = document.createElement("div");
+    item.className = "grid-item";
+    const img = document.createElement("img");
+    img.src = `file://${p}`;
+    item.appendChild(img);
+    item.ondblclick = () => window.electronAPI.openFile(p);
+    grid.appendChild(item);
+  });
+}
+
+window.electronAPI.getScreenshots().then(renderGrid);
+window.electronAPI.onScreenshotsUpdated(renderGrid);
+


### PR DESCRIPTION
## Summary
- show screenshot grid in the renderer
- watch Desktop folder from main process and expose API in preload
- render grid and open file on double click
- style grid layout with CSS

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_6841c49c4dc8832c8ba3046a171f7485